### PR TITLE
Improve Productive cache with SQLite

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,3 +55,30 @@ jobs:
       - run: composer install
 
       - run: composer run lint:static
+
+  phpunit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          extensions: pdo_sqlite
+
+      - run: composer install
+
+      - run: php -r "new PDO('sqlite::memory:');"
+
+      - run: composer test

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /vendor/
+/.phpunit.cache/
 /cache/
 /prefs.plist
 /.env

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 
+### Changed
+
+- Replace the filesystem cache with an indexed SQLite cache.
+- Publish cache refreshes atomically and preserve the last successful data when a refresh fails.
+- Coordinate concurrent background refreshes with per-resource locks.
+
 ## v0.0.6 - 2024.05.29
 
 ### Fixed

--- a/composer.json
+++ b/composer.json
@@ -2,8 +2,9 @@
   "require": {
     "php": "^8.2",
     "brandlabs/productiveio": "^0.1.1",
+    "ext-pdo": "*",
+    "ext-pdo_sqlite": "*",
     "illuminate/collections": "^10.47",
-    "symfony/cache": "^7.0",
     "vlucas/phpdotenv": "^5.6"
   },
   "config": {
@@ -32,6 +33,7 @@
   },
   "require-dev": {
     "phpstan/phpstan": "^1.10",
+    "phpunit/phpunit": "^10.5",
     "squizlabs/php_codesniffer": "^3.9"
   },
   "scripts": {
@@ -41,6 +43,7 @@
     ],
     "lint:style": "phpcs",
     "lint:static": "phpstan analyze",
+    "test": "phpunit",
     "fix": [
       "@fix:style"
     ],

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6f0c637ef82016e134c773c199751970",
+    "content-hash": "af6ece247c3e437c64c30873eb2d1354",
     "packages": [
         {
             "name": "brandlabs/productiveio",
@@ -687,55 +687,6 @@
             "time": "2024-07-20T21:41:07+00:00"
         },
         {
-            "name": "psr/cache",
-            "version": "3.0.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/cache.git",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/cache/zipball/aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
-                "reference": "aa5030cfa5405eccfdcb1083ce040c2cb8d253bf",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Cache\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for caching libraries",
-            "keywords": [
-                "cache",
-                "psr",
-                "psr-6"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/cache/tree/3.0.0"
-            },
-            "time": "2021-02-03T23:26:27+00:00"
-        },
-        {
             "name": "psr/container",
             "version": "2.0.2",
             "source": {
@@ -842,56 +793,6 @@
             "time": "2023-04-04T09:50:52+00:00"
         },
         {
-            "name": "psr/log",
-            "version": "3.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/log.git",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Log\\": "src"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for logging libraries",
-            "homepage": "https://github.com/php-fig/log",
-            "keywords": [
-                "log",
-                "psr",
-                "psr-3"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.2"
-            },
-            "time": "2024-09-11T13:17:53+00:00"
-        },
-        {
             "name": "psr/simple-cache",
             "version": "3.0.0",
             "source": {
@@ -985,247 +886,6 @@
                 "source": "https://github.com/ralouphie/getallheaders/tree/develop"
             },
             "time": "2019-03-08T08:55:37+00:00"
-        },
-        {
-            "name": "symfony/cache",
-            "version": "v7.2.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/cache.git",
-                "reference": "8b49dde3f5a5e9867595a3a269977f78418d75ee"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache/zipball/8b49dde3f5a5e9867595a3a269977f78418d75ee",
-                "reference": "8b49dde3f5a5e9867595a3a269977f78418d75ee",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2",
-                "psr/cache": "^2.0|^3.0",
-                "psr/log": "^1.1|^2|^3",
-                "symfony/cache-contracts": "^2.5|^3",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/service-contracts": "^2.5|^3",
-                "symfony/var-exporter": "^6.4|^7.0"
-            },
-            "conflict": {
-                "doctrine/dbal": "<3.6",
-                "symfony/dependency-injection": "<6.4",
-                "symfony/http-kernel": "<6.4",
-                "symfony/var-dumper": "<6.4"
-            },
-            "provide": {
-                "psr/cache-implementation": "2.0|3.0",
-                "psr/simple-cache-implementation": "1.0|2.0|3.0",
-                "symfony/cache-implementation": "1.1|2.0|3.0"
-            },
-            "require-dev": {
-                "cache/integration-tests": "dev-master",
-                "doctrine/dbal": "^3.6|^4",
-                "predis/predis": "^1.1|^2.0",
-                "psr/simple-cache": "^1.0|^2.0|^3.0",
-                "symfony/clock": "^6.4|^7.0",
-                "symfony/config": "^6.4|^7.0",
-                "symfony/dependency-injection": "^6.4|^7.0",
-                "symfony/filesystem": "^6.4|^7.0",
-                "symfony/http-kernel": "^6.4|^7.0",
-                "symfony/messenger": "^6.4|^7.0",
-                "symfony/var-dumper": "^6.4|^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\Cache\\": ""
-                },
-                "classmap": [
-                    "Traits/ValueWrapper.php"
-                ],
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Provides extended PSR-6, PSR-16 (and tags) implementations",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "caching",
-                "psr6"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/cache/tree/v7.2.6"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-04-08T09:06:23+00:00"
-        },
-        {
-            "name": "symfony/cache-contracts",
-            "version": "v3.5.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/cache-contracts.git",
-                "reference": "15a4f8e5cd3bce9aeafc882b1acab39ec8de2c1b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/15a4f8e5cd3bce9aeafc882b1acab39ec8de2c1b",
-                "reference": "15a4f8e5cd3bce9aeafc882b1acab39ec8de2c1b",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/cache": "^3.0"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.5-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Cache\\": ""
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to caching",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/cache-contracts/tree/v3.5.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-25T14:20:29+00:00"
-        },
-        {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.5.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
-                "reference": "74c71c939a79f7d5bf3c1ce9f5ea37ba0114c6f6",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.5-dev"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
-            "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-25T14:20:29+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -1632,165 +1292,6 @@
             "time": "2025-01-02T08:10:11+00:00"
         },
         {
-            "name": "symfony/service-contracts",
-            "version": "v3.5.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
-                "reference": "e53260aabf78fb3d63f8d79d69ece59f80d5eda0",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.1",
-                "psr/container": "^1.1|^2.0",
-                "symfony/deprecation-contracts": "^2.5|^3"
-            },
-            "conflict": {
-                "ext-psr": "<1.1|>=2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/contracts",
-                    "name": "symfony/contracts"
-                },
-                "branch-alias": {
-                    "dev-main": "3.5-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Contracts\\Service\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Test/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Generic abstractions related to writing services",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "abstractions",
-                "contracts",
-                "decoupling",
-                "interfaces",
-                "interoperability",
-                "standards"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.5.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2024-09-25T14:20:29+00:00"
-        },
-        {
-            "name": "symfony/var-exporter",
-            "version": "v7.2.6",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/var-exporter.git",
-                "reference": "422b8de94c738830a1e071f59ad14d67417d7007"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/422b8de94c738830a1e071f59ad14d67417d7007",
-                "reference": "422b8de94c738830a1e071f59ad14d67417d7007",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "require-dev": {
-                "symfony/property-access": "^6.4|^7.0",
-                "symfony/serializer": "^6.4|^7.0",
-                "symfony/var-dumper": "^6.4|^7.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Symfony\\Component\\VarExporter\\": ""
-                },
-                "exclude-from-classmap": [
-                    "/Tests/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "clone",
-                "construct",
-                "export",
-                "hydrate",
-                "instantiate",
-                "lazy-loading",
-                "proxy",
-                "serialize"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/var-exporter/tree/v7.2.6"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2025-05-02T08:36:00+00:00"
-        },
-        {
             "name": "vlucas/phpdotenv",
             "version": "v5.6.2",
             "source": {
@@ -1877,6 +1378,241 @@
     ],
     "packages-dev": [
         {
+            "name": "myclabs/deep-copy",
+            "version": "1.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/myclabs/DeepCopy.git",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/myclabs/DeepCopy/zipball/07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "reference": "07d290f0c47959fd5eed98c95ee5602db07e0b6a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.6.8",
+                "doctrine/common": "<2.13.3 || >=3 <3.2.2"
+            },
+            "require-dev": {
+                "doctrine/collections": "^1.6.8",
+                "doctrine/common": "^2.13.3 || ^3.2.2",
+                "phpspec/prophecy": "^1.10",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.23 || ^9.5.13"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/DeepCopy/deep_copy.php"
+                ],
+                "psr-4": {
+                    "DeepCopy\\": "src/DeepCopy/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Create deep copies (clones) of your objects",
+            "keywords": [
+                "clone",
+                "copy",
+                "duplicate",
+                "object",
+                "object graph"
+            ],
+            "support": {
+                "issues": "https://github.com/myclabs/DeepCopy/issues",
+                "source": "https://github.com/myclabs/DeepCopy/tree/1.13.4"
+            },
+            "funding": [
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/myclabs/deep-copy",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-01T08:46:24+00:00"
+        },
+        {
+            "name": "nikic/php-parser",
+            "version": "v5.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/nikic/PHP-Parser.git",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "reference": "044a6a392ff8ad0d61f14370a5fbbd0a0107152f",
+                "shasum": ""
+            },
+            "require": {
+                "ext-json": "*",
+                "ext-tokenizer": "*",
+                "php": ">=7.4"
+            },
+            "require-dev": {
+                "ircmaxell/php-yacc": "^0.0.7",
+                "phpunit/phpunit": "^9.0"
+            },
+            "bin": [
+                "bin/php-parse"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PhpParser\\": "lib/PhpParser"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Nikita Popov"
+                }
+            ],
+            "description": "A PHP parser written in PHP",
+            "keywords": [
+                "parser",
+                "php"
+            ],
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.8.0"
+            },
+            "time": "2026-07-04T14:30:18+00:00"
+        },
+        {
+            "name": "phar-io/manifest",
+            "version": "2.0.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/manifest.git",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/54750ef60c58e43759730615a392c31c80e23176",
+                "reference": "54750ef60c58e43759730615a392c31c80e23176",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-phar": "*",
+                "ext-xmlwriter": "*",
+                "phar-io/version": "^3.0.1",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-03T12:33:53+00:00"
+        },
+        {
+            "name": "phar-io/version",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phar-io/version.git",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phar-io/version/zipball/4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "reference": "4f7fd7836c6f332bb2933569e566a0d6c4cbed74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Heuer",
+                    "email": "sebastian@phpeople.de",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.2.1"
+            },
+            "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
             "name": "phpstan/phpstan",
             "version": "1.12.25",
             "source": {
@@ -1933,6 +1669,1373 @@
                 }
             ],
             "time": "2025-04-27T12:20:45+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "10.1.16",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-libxml": "*",
+                "ext-xmlwriter": "*",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
+                "php": ">=8.1",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
+                "theseer/tokenizer": "^1.2.3"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.1"
+            },
+            "suggest": {
+                "ext-pcov": "PHP extension that provides line coverage",
+                "ext-xdebug": "PHP extension that provides line coverage as well as branch and path coverage"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that provides collection, processing, and rendering functionality for PHP code coverage information.",
+            "homepage": "https://github.com/sebastianbergmann/php-code-coverage",
+            "keywords": [
+                "coverage",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-08-22T04:31:57+00:00"
+        },
+        {
+            "name": "phpunit/php-file-iterator",
+            "version": "4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "reference": "a95037b6d9e608ba092da1b23931e537cadc3c3c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "FilterIterator implementation that filters files based on a list of suffixes.",
+            "homepage": "https://github.com/sebastianbergmann/php-file-iterator/",
+            "keywords": [
+                "filesystem",
+                "iterator"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T06:24:48+00:00"
+        },
+        {
+            "name": "phpunit/php-invoker",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-invoker.git",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "reference": "f5e568ba02fa5ba0ddd0f618391d5a9ea50b06d7",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-pcntl": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-pcntl": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Invoke callables with a timeout",
+            "homepage": "https://github.com/sebastianbergmann/php-invoker/",
+            "keywords": [
+                "process"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:56:09+00:00"
+        },
+        {
+            "name": "phpunit/php-text-template",
+            "version": "3.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-text-template.git",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "reference": "0c7b06ff49e3d5072f057eb1fa59258bf287a748",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Simple template engine.",
+            "homepage": "https://github.com/sebastianbergmann/php-text-template/",
+            "keywords": [
+                "template"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/3.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-08-31T14:07:24+00:00"
+        },
+        {
+            "name": "phpunit/php-timer",
+            "version": "6.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-timer.git",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "reference": "e2a2d67966e740530f4a3343fe2e030ffdc1161d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Utility class for timing",
+            "homepage": "https://github.com/sebastianbergmann/php-timer/",
+            "keywords": [
+                "timer"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/6.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:57:52+00:00"
+        },
+        {
+            "name": "phpunit/phpunit",
+            "version": "10.5.64",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/phpunit.git",
+                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
+                "reference": "0e8c1d19cea35ad97d4887f363d07c78e30fbf06",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-filter": "*",
+                "ext-json": "*",
+                "ext-libxml": "*",
+                "ext-mbstring": "*",
+                "ext-xmlwriter": "*",
+                "myclabs/deep-copy": "^1.13.4",
+                "phar-io/manifest": "^2.0.4",
+                "phar-io/version": "^3.2.1",
+                "php": ">=8.1",
+                "phpunit/php-code-coverage": "^10.1.16",
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-invoker": "^4.0.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "phpunit/php-timer": "^6.0.0",
+                "sebastian/cli-parser": "^2.0.1",
+                "sebastian/code-unit": "^2.0.0",
+                "sebastian/comparator": "^5.0.5",
+                "sebastian/diff": "^5.1.1",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/exporter": "^5.1.4",
+                "sebastian/global-state": "^6.0.2",
+                "sebastian/object-enumerator": "^5.0.0",
+                "sebastian/recursion-context": "^5.0.1",
+                "sebastian/type": "^4.0.0",
+                "sebastian/version": "^4.0.1"
+            },
+            "suggest": {
+                "ext-soap": "To be able to generate mocks based on WSDL files"
+            },
+            "bin": [
+                "phpunit"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "10.5-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Framework/Assert/Functions.php"
+                ],
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "The PHP Unit Testing framework.",
+            "homepage": "https://phpunit.de/",
+            "keywords": [
+                "phpunit",
+                "testing",
+                "xunit"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.64"
+            },
+            "funding": [
+                {
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
+                }
+            ],
+            "time": "2026-07-06T14:50:35+00:00"
+        },
+        {
+            "name": "sebastian/cli-parser",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/cli-parser.git",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "reference": "c34583b87e7b7a8055bf6c450c2c77ce32a24084",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for parsing CLI options",
+            "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/2.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:12:49+00:00"
+        },
+        {
+            "name": "sebastian/code-unit",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit.git",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/a81fee9eef0b7a76af11d121767abc44c104e503",
+                "reference": "a81fee9eef0b7a76af11d121767abc44c104e503",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/2.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:58:43+00:00"
+        },
+        {
+            "name": "sebastian/code-unit-reverse-lookup",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "reference": "5e3a687f7d8ae33fb362c5c0743794bbb2420a1d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Looks up which function or method a line of code belongs to",
+            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T06:59:15+00:00"
+        },
+        {
+            "name": "sebastian/comparator",
+            "version": "5.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/comparator.git",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "reference": "55dfef806eb7dfeb6e7a6935601fef866f8ca48d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/diff": "^5.0",
+                "sebastian/exporter": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@2bepublished.at"
+                }
+            ],
+            "description": "Provides the functionality to compare PHP values for equality",
+            "homepage": "https://github.com/sebastianbergmann/comparator",
+            "keywords": [
+                "comparator",
+                "compare",
+                "equality"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "security": "https://github.com/sebastianbergmann/comparator/security/policy",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/5.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/comparator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2026-01-24T09:25:16+00:00"
+        },
+        {
+            "name": "sebastian/complexity",
+            "version": "3.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/complexity.git",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/68ff824baeae169ec9f2137158ee529584553799",
+                "reference": "68ff824baeae169ec9f2137158ee529584553799",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.2-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for calculating the complexity of PHP code units",
+            "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "security": "https://github.com/sebastianbergmann/complexity/security/policy",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/3.2.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:37:17+00:00"
+        },
+        {
+            "name": "sebastian/diff",
+            "version": "5.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/diff.git",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "reference": "c41e007b4b62af48218231d6c2275e4c9b975b2e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0",
+                "symfony/process": "^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Kore Nordmann",
+                    "email": "mail@kore-nordmann.de"
+                }
+            ],
+            "description": "Diff implementation",
+            "homepage": "https://github.com/sebastianbergmann/diff",
+            "keywords": [
+                "diff",
+                "udiff",
+                "unidiff",
+                "unified diff"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "security": "https://github.com/sebastianbergmann/diff/security/policy",
+                "source": "https://github.com/sebastianbergmann/diff/tree/5.1.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:15:17+00:00"
+        },
+        {
+            "name": "sebastian/environment",
+            "version": "6.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/environment.git",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/8074dbcd93529b357029f5cc5058fd3e43666984",
+                "reference": "8074dbcd93529b357029f5cc5058fd3e43666984",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "suggest": {
+                "ext-posix": "*"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Provides functionality to handle HHVM/PHP environments",
+            "homepage": "https://github.com/sebastianbergmann/environment",
+            "keywords": [
+                "Xdebug",
+                "environment",
+                "hhvm"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "security": "https://github.com/sebastianbergmann/environment/security/policy",
+                "source": "https://github.com/sebastianbergmann/environment/tree/6.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-23T08:47:14+00:00"
+        },
+        {
+            "name": "sebastian/exporter",
+            "version": "5.1.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/exporter.git",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/0735b90f4da94969541dac1da743446e276defa6",
+                "reference": "0735b90f4da94969541dac1da743446e276defa6",
+                "shasum": ""
+            },
+            "require": {
+                "ext-mbstring": "*",
+                "php": ">=8.1",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.1-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Volker Dusch",
+                    "email": "github@wallbash.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                },
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                }
+            ],
+            "description": "Provides the functionality to export PHP variables for visualization",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
+            "keywords": [
+                "export",
+                "exporter"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "security": "https://github.com/sebastianbergmann/exporter/security/policy",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/5.1.4"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/exporter",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-09-24T06:09:11+00:00"
+        },
+        {
+            "name": "sebastian/global-state",
+            "version": "6.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/global-state.git",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "reference": "987bafff24ecc4c9ac418cab1145b96dd6e9cbd9",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "ext-dom": "*",
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "6.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Snapshotting of global state",
+            "homepage": "https://www.github.com/sebastianbergmann/global-state",
+            "keywords": [
+                "global state"
+            ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "security": "https://github.com/sebastianbergmann/global-state/security/policy",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/6.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2024-03-02T07:19:19+00:00"
+        },
+        {
+            "name": "sebastian/lines-of-code",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/lines-of-code.git",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "reference": "856e7f6a75a84e339195d48c556f23be2ebf75d0",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18 || ^5.0",
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library for counting the lines of code in PHP source code",
+            "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/2.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-12-21T08:38:20+00:00"
+        },
+        {
+            "name": "sebastian/object-enumerator",
+            "version": "5.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-enumerator.git",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "reference": "202d0e344a580d7f7d04b3fafce6933e59dae906",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "sebastian/object-reflector": "^3.0",
+                "sebastian/recursion-context": "^5.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Traverses array structures and object graphs to enumerate all referenced objects",
+            "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/5.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:08:32+00:00"
+        },
+        {
+            "name": "sebastian/object-reflector",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/object-reflector.git",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/24ed13d98130f0e7122df55d06c5c4942a577957",
+                "reference": "24ed13d98130f0e7122df55d06c5c4942a577957",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                }
+            ],
+            "description": "Allows reflection of object attributes, including inherited and non-public ones",
+            "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/3.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:06:18+00:00"
+        },
+        {
+            "name": "sebastian/recursion-context",
+            "version": "5.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/recursion-context.git",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "reference": "47e34210757a2f37a97dcd207d032e1b01e64c7a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.5"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "5.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
+                },
+                {
+                    "name": "Jeff Welch",
+                    "email": "whatthejeff@gmail.com"
+                },
+                {
+                    "name": "Adam Harvey",
+                    "email": "aharvey@php.net"
+                }
+            ],
+            "description": "Provides functionality to recursively process PHP variables",
+            "homepage": "https://github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/5.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/recursion-context",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2025-08-10T07:50:56+00:00"
+        },
+        {
+            "name": "sebastian/type",
+            "version": "4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/type.git",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/462699a16464c3944eefc02ebdd77882bd3925bf",
+                "reference": "462699a16464c3944eefc02ebdd77882bd3925bf",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^10.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Collection of value objects that represent the types of the PHP type system",
+            "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-03T07:10:45+00:00"
+        },
+        {
+            "name": "sebastian/version",
+            "version": "4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/version.git",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "reference": "c51fa83a5d8f43f1402e3f32a005e6262244ef17",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de",
+                    "role": "lead"
+                }
+            ],
+            "description": "Library that helps with managing the version number of Git-hosted PHP projects",
+            "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sebastianbergmann",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-02-07T11:34:05+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -2017,6 +3120,56 @@
                 }
             ],
             "time": "2025-04-13T04:10:18+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "1.3.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "authors": [
+                {
+                    "name": "Arne Blankerts",
+                    "email": "arne@blankerts.de",
+                    "role": "Developer"
+                }
+            ],
+            "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
+            "support": {
+                "issues": "https://github.com/theseer/tokenizer/issues",
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theseer",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-11-17T20:03:58+00:00"
         }
     ],
     "aliases": [],
@@ -2025,8 +3178,10 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^8.2"
+        "php": "^8.2",
+        "ext-pdo": "*",
+        "ext-pdo_sqlite": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+         cacheDirectory=".phpunit.cache"
+         failOnWarning="true"
+         failOnRisky="true">
+  <testsuites>
+    <testsuite name="integration">
+      <directory>tests/Integration</directory>
+    </testsuite>
+  </testsuites>
+</phpunit>

--- a/src/Cache/RefreshLock.php
+++ b/src/Cache/RefreshLock.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace Alfred\Productive\Cache;
+
+use RuntimeException;
+use function Alfred\Productive\Functions\utils\get_root_dir;
+
+class RefreshLock
+{
+    /** @var resource|null */
+    private $handle;
+
+    private string $path;
+
+    public function __construct(string $cacheKey, ?string $directory = null)
+    {
+        $directory = $directory ?: get_root_dir() . '/cache/locks';
+
+        if (!is_dir($directory) && !mkdir($directory, 0777, true) && !is_dir($directory)) {
+            throw new RuntimeException("Could not create the cache lock directory: {$directory}");
+        }
+
+        $this->path = $directory . '/' . hash('sha256', $cacheKey) . '.lock';
+    }
+
+    public function acquire(): bool
+    {
+        if (is_resource($this->handle)) {
+            return true;
+        }
+
+        $handle = fopen($this->path, 'c');
+        if ($handle === false) {
+            throw new RuntimeException("Could not open the cache refresh lock: {$this->path}");
+        }
+
+        if (!flock($handle, LOCK_EX | LOCK_NB)) {
+            fclose($handle);
+            return false;
+        }
+
+        $this->handle = $handle;
+
+        return true;
+    }
+
+    public function release(): void
+    {
+        if (is_resource($this->handle)) {
+            flock($this->handle, LOCK_UN);
+            fclose($this->handle);
+        }
+
+        $this->handle = null;
+    }
+
+    public function __destruct()
+    {
+        $this->release();
+    }
+}

--- a/src/Cache/SqliteStore.php
+++ b/src/Cache/SqliteStore.php
@@ -1,0 +1,514 @@
+<?php
+
+namespace Alfred\Productive\Cache;
+
+use PDO;
+use RuntimeException;
+use Throwable;
+use function Alfred\Productive\Functions\utils\get_root_dir;
+
+class SqliteStore
+{
+    private const SCHEMA_VERSION = 1;
+
+    private PDO $pdo;
+
+    public function __construct(?string $path = null)
+    {
+        if (!extension_loaded('pdo_sqlite')) {
+            throw new RuntimeException('The pdo_sqlite extension is required to use the cache.');
+        }
+
+        $path = $path ?: get_root_dir() . '/cache/productive.sqlite';
+        $directory = dirname($path);
+
+        if (!is_dir($directory) && !mkdir($directory, 0777, true) && !is_dir($directory)) {
+            throw new RuntimeException("Could not create the SQLite cache directory: {$directory}");
+        }
+
+        $initLock = fopen($directory . '/sqlite-init.lock', 'c');
+        if ($initLock === false) {
+            throw new RuntimeException('Could not open the SQLite initialization lock.');
+        }
+
+        if (!flock($initLock, LOCK_EX)) {
+            fclose($initLock);
+            throw new RuntimeException('Could not acquire the SQLite initialization lock.');
+        }
+
+        try {
+            $this->pdo = new PDO('sqlite:' . $path);
+            $this->pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
+            $this->pdo->setAttribute(PDO::ATTR_DEFAULT_FETCH_MODE, PDO::FETCH_ASSOC);
+            $this->configure();
+            $this->migrate();
+        } finally {
+            flock($initLock, LOCK_UN);
+            fclose($initLock);
+        }
+    }
+
+    public function hasPublishedGeneration(string $cacheKey): bool
+    {
+        $statement = $this->pdo->prepare(
+            'SELECT published_generation_id FROM cache_entries WHERE cache_key = :cache_key'
+        );
+        $statement->execute(['cache_key' => $cacheKey]);
+        $generationId = $statement->fetchColumn();
+
+        return $generationId !== false && !is_null($generationId);
+    }
+
+    public function isFresh(string $cacheKey, int $now): bool
+    {
+        $statement = $this->pdo->prepare(
+            'SELECT published_generation_id, expires_at
+            FROM cache_entries
+            WHERE cache_key = :cache_key'
+        );
+        $statement->execute(['cache_key' => $cacheKey]);
+        $entry = $statement->fetch();
+
+        return is_array($entry)
+            && !is_null($entry['published_generation_id'])
+            && !is_null($entry['expires_at'])
+            && (int)$entry['expires_at'] > $now;
+    }
+
+    public function countPublishedItems(string $cacheKey): int
+    {
+        $statement = $this->pdo->prepare(
+            'SELECT COUNT(*)
+            FROM cache_entries AS cache
+            INNER JOIN items ON items.generation_id = cache.published_generation_id
+            WHERE cache.cache_key = :cache_key'
+        );
+        $statement->execute(['cache_key' => $cacheKey]);
+
+        return (int)$statement->fetchColumn();
+    }
+
+    /**
+     * @return array<int, array<string, mixed>>
+     */
+    public function getItems(string $cacheKey, ?string $companyId = null, bool $openDealsOnly = false): array
+    {
+        $where = ['cache.cache_key = :cache_key'];
+        $parameters = ['cache_key' => $cacheKey];
+
+        if (!is_null($companyId)) {
+            $where[] = 'items.company_id = :company_id';
+            $parameters['company_id'] = $companyId;
+        }
+
+        if ($openDealsOnly) {
+            $where[] = 'items.related_deal_id IS NOT NULL';
+            $where[] = 'items.closed_at IS NULL';
+        }
+
+        $statement = $this->pdo->prepare(sprintf(
+            'SELECT items.item_json
+            FROM cache_entries AS cache
+            INNER JOIN items ON items.generation_id = cache.published_generation_id
+            WHERE %s
+            ORDER BY items.title COLLATE NOCASE ASC, items.uid ASC',
+            implode(' AND ', $where)
+        ));
+        $statement->execute($parameters);
+
+        $items = [];
+        foreach ($statement->fetchAll() as $row) {
+            $item = json_decode((string)$row['item_json'], true, 512, JSON_THROW_ON_ERROR);
+            if (!is_array($item)) {
+                throw new RuntimeException('The SQLite cache contains an invalid Alfred item.');
+            }
+            $items[] = $item;
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    public function beginRefresh(
+        string $cacheKey,
+        string $resourceClass,
+        array $parameters,
+        int $startedAt
+    ): int {
+        $this->pdo->beginTransaction();
+
+        try {
+            $this->ensureEntry($cacheKey, $resourceClass, $parameters);
+
+            $cleanup = $this->pdo->prepare(
+                'DELETE FROM cache_generations
+                WHERE cache_key = :cache_key
+                AND id != COALESCE(
+                    (SELECT published_generation_id FROM cache_entries WHERE cache_key = :cache_key),
+                    -1
+                )'
+            );
+            $cleanup->execute(['cache_key' => $cacheKey]);
+
+            $generation = $this->pdo->prepare(
+                'INSERT INTO cache_generations (cache_key, started_at, status)
+                VALUES (:cache_key, :started_at, :status)'
+            );
+            $generation->execute([
+                'cache_key' => $cacheKey,
+                'started_at' => $startedAt,
+                'status' => 'staging',
+            ]);
+            $generationId = (int)$this->pdo->lastInsertId();
+
+            $entry = $this->pdo->prepare(
+                'UPDATE cache_entries
+                SET last_attempt_at = :last_attempt_at, status = :status, error = NULL
+                WHERE cache_key = :cache_key'
+            );
+            $entry->execute([
+                'cache_key' => $cacheKey,
+                'last_attempt_at' => $startedAt,
+                'status' => 'refreshing',
+            ]);
+
+            $this->pdo->commit();
+
+            return $generationId;
+        } catch (Throwable $error) {
+            $this->pdo->rollBack();
+            throw $error;
+        }
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $items
+     */
+    public function stageItems(int $generationId, array $items, int $updatedAt): void
+    {
+        $statement = $this->pdo->prepare(
+            'INSERT INTO items (
+                generation_id, uid, title, subtitle, match, arg, company_id,
+                deal_id, related_deal_id, project_id, service_id, task_id,
+                closed_at, item_json, updated_at
+            ) VALUES (
+                :generation_id, :uid, :title, :subtitle, :match, :arg, :company_id,
+                :deal_id, :related_deal_id, :project_id, :service_id, :task_id,
+                :closed_at, :item_json, :updated_at
+            ) ON CONFLICT(generation_id, uid) DO UPDATE SET
+                title = excluded.title,
+                subtitle = excluded.subtitle,
+                match = excluded.match,
+                arg = excluded.arg,
+                company_id = excluded.company_id,
+                deal_id = excluded.deal_id,
+                related_deal_id = excluded.related_deal_id,
+                project_id = excluded.project_id,
+                service_id = excluded.service_id,
+                task_id = excluded.task_id,
+                closed_at = excluded.closed_at,
+                item_json = excluded.item_json,
+                updated_at = excluded.updated_at'
+        );
+
+        $this->pdo->beginTransaction();
+
+        try {
+            foreach ($items as $item) {
+                $uid = $this->stringOrNull($item['uid'] ?? null);
+                if (is_null($uid)) {
+                    throw new RuntimeException('Every cached Alfred item must have a non-empty uid.');
+                }
+
+                $statement->execute([
+                    'generation_id' => $generationId,
+                    'uid' => $uid,
+                    'title' => (string)($item['title'] ?? ''),
+                    'subtitle' => (string)($item['subtitle'] ?? ''),
+                    'match' => (string)($item['match'] ?? ''),
+                    'arg' => (string)($item['arg'] ?? ''),
+                    'company_id' => $this->extractCompanyId($item),
+                    'deal_id' => $this->stringOrNull($this->arrayGet($item, 'variables.deal_id')),
+                    'related_deal_id' => $this->stringOrNull(
+                        $this->arrayGet($item, 'variables.relationships.deal.id')
+                    ),
+                    'project_id' => $this->stringOrNull($this->arrayGet($item, 'variables.project_id')),
+                    'service_id' => $this->stringOrNull($this->arrayGet($item, 'variables.service_id')),
+                    'task_id' => $this->stringOrNull($this->arrayGet($item, 'variables.task_id')),
+                    'closed_at' => $this->extractClosedAt($item),
+                    'item_json' => $this->encodeJson($item),
+                    'updated_at' => $updatedAt,
+                ]);
+            }
+
+            $this->pdo->commit();
+        } catch (Throwable $error) {
+            $this->pdo->rollBack();
+            throw $error;
+        }
+    }
+
+    public function publishRefresh(string $cacheKey, int $generationId, int $completedAt, int $ttl): void
+    {
+        $expiresAt = $completedAt + $ttl;
+        $this->pdo->beginTransaction();
+
+        try {
+            $generation = $this->pdo->prepare(
+                'UPDATE cache_generations
+                SET completed_at = :completed_at, expires_at = :expires_at, status = :status, error = NULL
+                WHERE id = :generation_id AND cache_key = :cache_key AND status = :staging_status'
+            );
+            $generation->execute([
+                'generation_id' => $generationId,
+                'cache_key' => $cacheKey,
+                'completed_at' => $completedAt,
+                'expires_at' => $expiresAt,
+                'status' => 'published',
+                'staging_status' => 'staging',
+            ]);
+
+            if ($generation->rowCount() !== 1) {
+                throw new RuntimeException('Could not publish the staged cache generation.');
+            }
+
+            $entry = $this->pdo->prepare(
+                'UPDATE cache_entries
+                SET published_generation_id = :generation_id,
+                    last_success_at = :last_success_at,
+                    expires_at = :expires_at,
+                    status = :status,
+                    error = NULL
+                WHERE cache_key = :cache_key'
+            );
+            $entry->execute([
+                'generation_id' => $generationId,
+                'last_success_at' => $completedAt,
+                'expires_at' => $expiresAt,
+                'status' => 'fresh',
+                'cache_key' => $cacheKey,
+            ]);
+
+            $cleanup = $this->pdo->prepare(
+                'DELETE FROM cache_generations WHERE cache_key = :cache_key AND id != :generation_id'
+            );
+            $cleanup->execute([
+                'cache_key' => $cacheKey,
+                'generation_id' => $generationId,
+            ]);
+
+            $this->pdo->commit();
+        } catch (Throwable $error) {
+            $this->pdo->rollBack();
+            throw $error;
+        }
+    }
+
+    public function failRefresh(string $cacheKey, int $generationId, Throwable $error): void
+    {
+        $this->pdo->beginTransaction();
+
+        try {
+            $delete = $this->pdo->prepare(
+                'DELETE FROM cache_generations WHERE id = :generation_id AND cache_key = :cache_key'
+            );
+            $delete->execute([
+                'generation_id' => $generationId,
+                'cache_key' => $cacheKey,
+            ]);
+
+            $entry = $this->pdo->prepare(
+                'UPDATE cache_entries SET status = :status, error = :error WHERE cache_key = :cache_key'
+            );
+            $entry->execute([
+                'status' => 'failed',
+                'error' => $error->getMessage(),
+                'cache_key' => $cacheKey,
+            ]);
+
+            $this->pdo->commit();
+        } catch (Throwable $failure) {
+            $this->pdo->rollBack();
+            throw $failure;
+        }
+    }
+
+    private function configure(): void
+    {
+        $this->pdo->exec('PRAGMA busy_timeout = 5000');
+        $this->pdo->exec('PRAGMA foreign_keys = ON');
+        $this->pdo->exec('PRAGMA journal_mode = WAL');
+        $this->pdo->exec('PRAGMA synchronous = NORMAL');
+    }
+
+    private function migrate(): void
+    {
+        $version = (int)$this->pdo->query('PRAGMA user_version')->fetchColumn();
+        if ($version > self::SCHEMA_VERSION) {
+            throw new RuntimeException("Unsupported SQLite cache schema version: {$version}");
+        }
+
+        if ($version < self::SCHEMA_VERSION) {
+            $this->pdo->beginTransaction();
+
+            try {
+                // PR #35 was never released. Its unversioned prototype cache is disposable and rebuilt safely.
+                $this->pdo->exec('DROP TABLE IF EXISTS items');
+                $this->pdo->exec('DROP TABLE IF EXISTS cache_generations');
+                $this->pdo->exec('DROP TABLE IF EXISTS cache_entries');
+                $this->createSchema();
+                $this->pdo->exec('PRAGMA user_version = ' . self::SCHEMA_VERSION);
+                $this->pdo->commit();
+            } catch (Throwable $error) {
+                $this->pdo->rollBack();
+                throw $error;
+            }
+
+            return;
+        }
+
+        $this->createSchema();
+    }
+
+    private function createSchema(): void
+    {
+        $this->pdo->exec(
+            'CREATE TABLE IF NOT EXISTS cache_entries (
+                cache_key TEXT PRIMARY KEY,
+                resource_class TEXT NOT NULL,
+                parameters_json TEXT NOT NULL DEFAULT "{}",
+                published_generation_id INTEGER,
+                last_success_at INTEGER,
+                last_attempt_at INTEGER,
+                expires_at INTEGER,
+                status TEXT NOT NULL DEFAULT "pending",
+                error TEXT
+            )'
+        );
+
+        $this->pdo->exec(
+            'CREATE TABLE IF NOT EXISTS cache_generations (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                cache_key TEXT NOT NULL,
+                started_at INTEGER NOT NULL,
+                completed_at INTEGER,
+                expires_at INTEGER,
+                status TEXT NOT NULL,
+                error TEXT,
+                FOREIGN KEY (cache_key) REFERENCES cache_entries(cache_key) ON DELETE CASCADE
+            )'
+        );
+
+        $this->pdo->exec(
+            'CREATE TABLE IF NOT EXISTS items (
+                generation_id INTEGER NOT NULL,
+                uid TEXT NOT NULL,
+                title TEXT NOT NULL DEFAULT "",
+                subtitle TEXT NOT NULL DEFAULT "",
+                match TEXT NOT NULL DEFAULT "",
+                arg TEXT NOT NULL DEFAULT "",
+                company_id TEXT,
+                deal_id TEXT,
+                related_deal_id TEXT,
+                project_id TEXT,
+                service_id TEXT,
+                task_id TEXT,
+                closed_at TEXT,
+                item_json TEXT NOT NULL,
+                updated_at INTEGER NOT NULL,
+                PRIMARY KEY (generation_id, uid),
+                FOREIGN KEY (generation_id) REFERENCES cache_generations(id) ON DELETE CASCADE
+            )'
+        );
+
+        $this->pdo->exec(
+            'CREATE INDEX IF NOT EXISTS cache_generations_cache_status_idx
+            ON cache_generations(cache_key, status)'
+        );
+        $this->pdo->exec(
+            'CREATE INDEX IF NOT EXISTS items_generation_company_idx
+            ON items(generation_id, company_id)'
+        );
+        $this->pdo->exec(
+            'CREATE INDEX IF NOT EXISTS items_generation_open_deal_idx
+            ON items(generation_id, related_deal_id, closed_at)'
+        );
+        $this->pdo->exec(
+            'CREATE INDEX IF NOT EXISTS items_generation_title_idx
+            ON items(generation_id, title COLLATE NOCASE, uid)'
+        );
+    }
+
+    /**
+     * @param array<string, mixed> $parameters
+     */
+    private function ensureEntry(string $cacheKey, string $resourceClass, array $parameters): void
+    {
+        $statement = $this->pdo->prepare(
+            'INSERT INTO cache_entries (cache_key, resource_class, parameters_json, status)
+            VALUES (:cache_key, :resource_class, :parameters_json, :status)
+            ON CONFLICT(cache_key) DO UPDATE SET
+                resource_class = excluded.resource_class,
+                parameters_json = excluded.parameters_json'
+        );
+        $statement->execute([
+            'cache_key' => $cacheKey,
+            'resource_class' => $resourceClass,
+            'parameters_json' => $this->encodeJson($parameters),
+            'status' => 'pending',
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $array
+     */
+    private function arrayGet(array $array, string $path): mixed
+    {
+        $current = $array;
+        foreach (explode('.', $path) as $part) {
+            if (!is_array($current) || !array_key_exists($part, $current)) {
+                return null;
+            }
+            $current = $current[$part];
+        }
+
+        return $current;
+    }
+
+    /**
+     * @param array<string, mixed> $item
+     */
+    private function extractCompanyId(array $item): ?string
+    {
+        return $this->stringOrNull($this->arrayGet($item, 'variables.company_id'))
+            ?? $this->stringOrNull($this->arrayGet($item, 'variables.relationships.company.id'))
+            ?? $this->stringOrNull($this->arrayGet($item, 'variables.relationships.deal.relationships.company.id'));
+    }
+
+    /**
+     * @param array<string, mixed> $item
+     */
+    private function extractClosedAt(array $item): ?string
+    {
+        return $this->stringOrNull($this->arrayGet($item, 'variables.relationships.deal.attributes.closed_at'));
+    }
+
+    /**
+     * @param array<mixed> $data
+     */
+    private function encodeJson(array $data): string
+    {
+        return json_encode($data, JSON_THROW_ON_ERROR);
+    }
+
+    private function stringOrNull(mixed $value): ?string
+    {
+        if (is_null($value) || $value === '') {
+            return null;
+        }
+
+        return (string)$value;
+    }
+}

--- a/src/Functions/Resources/fetch.php
+++ b/src/Functions/Resources/fetch.php
@@ -2,6 +2,8 @@
 
 namespace Alfred\Productive\Functions\Resources\fetch;
 
+use Alfred\Productive\Cache\RefreshLock;
+use Alfred\Productive\Cache\SqliteStore;
 use Alfred\Productive\Resources\Deals;
 use Alfred\Productive\Resources\Services;
 use Brandlabs\Productiveio\Resources\Companies;
@@ -9,148 +11,248 @@ use Brandlabs\Productiveio\Resources\People;
 use Brandlabs\Productiveio\Resources\Projects;
 use Brandlabs\Productiveio\Resources\Tasks;
 use Brandlabs\Productiveio\Resources\TimeEntries;
+use RuntimeException;
+use Throwable;
 use function Alfred\Productive\Functions\Resources\utils\get_resource_name;
 use function Alfred\Productive\Functions\Resources\utils\validate_resource_class;
 use function Alfred\Productive\Functions\Resources\utils\merge_relationships;
 use function Alfred\Productive\Functions\cache\generate_cache_key;
-use function Alfred\Productive\Functions\cache\get_cache;
 use function Alfred\Productive\Functions\client\get_client;
 use function Alfred\Productive\Functions\env\get_update_interval;
 use function Alfred\Productive\Functions\utils\logger;
 
-function fetch_all_by_resource(string $resource_class, callable $resource_formatter, array $parameters = [])
-{
+/**
+ * @param array<string, mixed> $parameters
+ * @param null|callable(array<string, mixed>): array<string, mixed> $pageFetcher
+ * @param null|callable(): int $clock
+ * @return array<int, array<string, mixed>>
+ */
+function fetch_all_by_resource(
+    string $resource_class,
+    callable $resource_formatter,
+    array $parameters = [],
+    ?SqliteStore $store = null,
+    ?callable $pageFetcher = null,
+    ?callable $clock = null,
+    ?RefreshLock $lock = null,
+    float $coldCacheWaitSeconds = 30.0
+): array {
     logger('fetch_all_by_resource', $resource_class, $resource_formatter, $parameters);
     $resource_name = get_resource_name($resource_class);
     $logger = fn (...$args) => logger("[{$resource_name}]", ...$args);
     $logger('fetch_all_by_resource', $resource_formatter, json_encode($parameters));
 
-    $cache = get_cache();
-
-
     validate_resource_class($resource_class);
 
-    $client = get_client();
-    /** @var Projects|Tasks|Companies|Deals|Services|People|TimeEntries */
-    $resource = new $resource_class($client);
-
+    $store = $store ?: new SqliteStore();
+    $clock = $clock ?: fn (): int => time();
     $cache_key = generate_cache_key($resource_class, $parameters);
-    $cache_item = $cache->getItem($cache_key);
-    $cached_items = collect($cache_item->get());
-
-    $last_update_item = $cache->getItem(md5('last_update_' . $resource_class));
     $update_interval = get_update_interval();
-    if ($cached_items->isNotEmpty() && $last_update_item->isHit()) {
+
+    if ($store->isFresh($cache_key, $clock())) {
         $logger("last fetch happened less than {$update_interval} seconds ago, not fetching.");
-        return;
-    } else {
-        $last_update_item->expiresAfter($update_interval);
-        $cache->save($last_update_item);
+        return $store->getItems($cache_key);
     }
 
-    $logger('fetch_all_by_resource', $cache_key);
+    $lock = $lock ?: new RefreshLock($cache_key);
+    $hasLock = $lock->acquire();
 
-    $current_page = 1;
-    $page_size = 200;
-    $parameters = ['page[size]' => $page_size, 'page[number]' => $current_page] + $parameters;
+    if (!$hasLock) {
+        $logger('another cache refresh is already running');
 
-    $logger(
-        'fetch_all_by_resource',
-        [
-                'current_page' => $current_page,
-                'page_size' => $page_size,
-                'cache_count' => count($cache_item->get() ?? []),
-            ],
-    );
+        if ($store->hasPublishedGeneration($cache_key)) {
+            return $store->getItems($cache_key);
+        }
 
-    $response = $resource->getList($parameters);
-    $data = $response['data'];
-    $included = $response['included'];
+        $deadline = microtime(true) + $coldCacheWaitSeconds;
+        do {
+            usleep(250000);
 
-    $items = array_values(
-        $cached_items->concat(
-            array_map(
-                $resource_formatter,
-                merge_relationships($data, $included)
-            )
-        )->reverse()->unique('uid')->all()
-    );
+            /** @phpstan-ignore-next-line The store may be published by another process while sleeping. */
+            if ($store->hasPublishedGeneration($cache_key)) {
+                return $store->getItems($cache_key);
+            }
 
-    $cache_item->set($items);
-    $cache->save($cache_item);
+            $hasLock = $lock->acquire();
+        } while (!$hasLock && microtime(true) < $deadline);
 
-    while ($current_page < $response['meta']['total_pages']) {
-        $current_page += 1;
-
-        $logger(
-            'fetch_all_by_resource',
-            [
-                'current_page' => $current_page,
-                'page_size' => $page_size,
-                'cache_count' => count($cache_item->get() ?? []),
-                'response_pages' => $response['meta']['total_pages'],
-                'response_count' => $response['meta']['total_count'],
-            ],
-        );
-
-        $response = $resource->getList([
-            'page[size]' => $page_size,
-            'page[number]' => $current_page
-        ] + $parameters);
-
-        $data = array_merge($data, $response['data']);
-        $included = array_merge($included, $response['included']);
-        $cached_items = collect($cache_item->get());
-        $items = array_values(
-            $cached_items->concat(
-                array_map(
-                    $resource_formatter,
-                    merge_relationships($data, $included)
-                )
-            )->reverse()->unique('uid')->all()
-        );
-        $cache_item->set($items);
-        $cache->save($cache_item);
+        if (!$hasLock) {
+            $logger('initial cache refresh did not finish before the wait timeout');
+            return [];
+        }
     }
 
-    // Remove obsolete items from the cache
-    $new_ids = collect($data)->pluck('id');
-    $cached_items = collect($cache_item->get());
+    try {
+        // Another process may have refreshed the cache immediately before this process acquired the lock.
+        /** @phpstan-ignore-next-line The store may change in another process before lock acquisition. */
+        if ($store->isFresh($cache_key, $clock())) {
+            $logger("last fetch happened less than {$update_interval} seconds ago, not fetching.");
+            return $store->getItems($cache_key);
+        }
 
-    $filtered_items = $cached_items->filter(function ($item) use ($new_ids) {
-        return $new_ids->contains($item['uid']);
-    });
-    $cache_item->set(array_values($filtered_items->all()));
-    $cache->save($cache_item);
+        if (is_null($pageFetcher)) {
+            $client = get_client();
+            /** @var Projects|Tasks|Companies|Deals|Services|People|TimeEntries $resource */
+            $resource = new $resource_class($client);
+            $pageFetcher = fn (array $pageParameters): array => $resource->getList($pageParameters);
+        }
 
-    $logger(
-        'previously cached items:',
-        count($cached_items),
-        'cached items without obsolete items:',
-        count($filtered_items)
-    );
+        refresh_generation(
+            $store,
+            $cache_key,
+            $resource_class,
+            $parameters,
+            $resource_formatter,
+            $pageFetcher,
+            $update_interval,
+            $clock,
+            $logger
+        );
+
+        $logger('cached items:', $store->countPublishedItems($cache_key));
+
+        return $store->getItems($cache_key);
+    } catch (Throwable $error) {
+        $logger('fetch failed, keeping stale cache:', $error->getMessage());
+        return $store->getItems($cache_key);
+    } finally {
+        $lock->release();
+    }
 }
 
-function get_all_by_resource_from_cache(string $resource_class, array $parameters = []):array
-{
+/**
+ * @param array<string, mixed> $parameters
+ * @param callable(array<string, mixed>): array<string, mixed> $pageFetcher
+ * @param callable(): int $clock
+ * @param null|callable(mixed...): void $logger
+ */
+function refresh_generation(
+    SqliteStore $store,
+    string $cacheKey,
+    string $resourceClass,
+    array $parameters,
+    callable $resourceFormatter,
+    callable $pageFetcher,
+    int $updateInterval,
+    callable $clock,
+    ?callable $logger = null
+): void {
+    $generationId = $store->beginRefresh($cacheKey, $resourceClass, $parameters, $clock());
+    $currentPage = 1;
+    $totalPages = 1;
+    $pageSize = 200;
+
+    try {
+        do {
+            $pageParameters = [
+                'page[size]' => $pageSize,
+                'page[number]' => $currentPage,
+            ] + $parameters;
+
+            if (!is_null($logger)) {
+                $logger('fetch_all_by_resource', [
+                    'current_page' => $currentPage,
+                    'page_size' => $pageSize,
+                    'published_count' => $store->countPublishedItems($cacheKey),
+                    'response_pages' => $totalPages,
+                ]);
+            }
+
+            $response = $pageFetcher($pageParameters);
+            $data = $response['data'] ?? null;
+            $included = $response['included'] ?? [];
+
+            if (!is_array($data)) {
+                throw new RuntimeException('Productive returned an invalid data collection.');
+            }
+
+            if (!is_array($included)) {
+                throw new RuntimeException('Productive returned an invalid included collection.');
+            }
+
+            if (!isset($response['meta']) || !is_array($response['meta'])
+                || !array_key_exists('total_pages', $response['meta'])
+            ) {
+                throw new RuntimeException('Productive returned missing pagination metadata.');
+            }
+
+            $responsePages = $response['meta']['total_pages'];
+            if (!is_int($responsePages) && !ctype_digit((string)$responsePages)) {
+                throw new RuntimeException('Productive returned invalid pagination metadata.');
+            }
+            $totalPages = (int)$responsePages;
+
+            if ($totalPages < 0 || ($totalPages < $currentPage && !empty($data))) {
+                throw new RuntimeException('Productive returned inconsistent pagination metadata.');
+            }
+
+            $items = array_values(array_filter(array_map(
+                $resourceFormatter,
+                merge_relationships($data, $included)
+            )));
+            $store->stageItems($generationId, $items, $clock());
+
+            $currentPage += 1;
+        } while ($currentPage <= $totalPages);
+
+        $store->publishRefresh($cacheKey, $generationId, $clock(), $updateInterval);
+    } catch (Throwable $error) {
+        try {
+            $store->failRefresh($cacheKey, $generationId, $error);
+        } catch (Throwable $failure) {
+            if (!is_null($logger)) {
+                $logger('failed to clean staged cache:', $failure->getMessage());
+            }
+        }
+
+        throw $error;
+    }
+}
+
+/**
+ * @param array<string, mixed> $parameters
+ * @param null|callable(array<string, mixed>): array<string, mixed> $page_fetcher
+ * @param null|callable(): int $clock
+ * @return array<int, array<string, mixed>>
+ */
+function get_all_by_resource_from_cache(
+    string $resource_class,
+    callable $resource_formatter,
+    array $parameters = [],
+    ?string $company_id = null,
+    bool $open_deals_only = false,
+    ?SqliteStore $store = null,
+    ?callable $page_fetcher = null,
+    ?callable $clock = null,
+    ?RefreshLock $lock = null,
+    float $cold_cache_wait_seconds = 30.0
+): array {
     $resource_name = get_resource_name($resource_class);
     $logger = fn (...$args) => logger("[{$resource_name}]", ...$args);
     $logger('get_all_by_resource_from_cache', json_encode($parameters));
 
-    $cache = get_cache();
+    validate_resource_class($resource_class);
+
+    $store = $store ?: new SqliteStore();
     $cache_key = generate_cache_key($resource_class, $parameters);
-    $cache_item = $cache->getItem($cache_key);
 
-    $logger('get_all_by_resource_from_cache', $cache_key, $cache_item->isHit() ? 'hit' : 'miss');
-    $loop = 0;
-
-    while (!$cache_item->isHit() && $loop < 1000) {
-        sleep(1);
-        $loop++;
-        $cache_item = $cache->getItem($cache_key);
-        $logger('get_all_by_resource_from_cache', 'nothing to display');
+    if ($store->hasPublishedGeneration($cache_key)) {
+        $items = $store->getItems($cache_key, $company_id, $open_deals_only);
+        $logger('get_all_by_resource_from_cache', $cache_key, 'hit', count($items));
+        return $items;
     }
 
-    $items = $cache_item->get();
-    return $items;
+    $logger('get_all_by_resource_from_cache', $cache_key, 'cache miss');
+    fetch_all_by_resource(
+        $resource_class,
+        $resource_formatter,
+        $parameters,
+        $store,
+        $page_fetcher,
+        $clock,
+        $lock,
+        $cold_cache_wait_seconds
+    );
+
+    return $store->getItems($cache_key, $company_id, $open_deals_only);
 }

--- a/src/Functions/Resources/utils.php
+++ b/src/Functions/Resources/utils.php
@@ -8,13 +8,20 @@ use Brandlabs\Productiveio\BaseResource;
 
 function merge_relationships(array $data, array $included): array
 {
-    $included_collection = collect($included);
+    $included_index = [];
+    foreach ($included as $item) {
+        if (isset($item['type'], $item['id'])) {
+            $included_index[$item['type']][$item['id']] = $item;
+        }
+    }
+
     $merged = [];
     foreach ($data as $row) {
         $new_row = $row;
         $new_row['included'] = $included;
 
         if (!isset($row['relationships'])) {
+            $merged[] = $new_row;
             continue;
         }
 
@@ -26,14 +33,12 @@ function merge_relationships(array $data, array $included): array
                 continue;
             }
 
-            $resolved_relationship = $included_collection->where('type', $type)->where('id', $id)->first();
+            $resolved_relationship = $included_index[$type][$id] ?? null;
 
             // Resolve companies relationships for projects and deals
             if (in_array($type, ['projects','deals']) && isset($resolved_relationship['relationships']['company'])) {
-                $company = $included_collection
-                    ->where('type', 'companies')
-                    ->where('id', $resolved_relationship['relationships']['company']['data']['id'])
-                    ->first();
+                $company_id = $resolved_relationship['relationships']['company']['data']['id'] ?? null;
+                $company = $included_index['companies'][$company_id] ?? null;
 
                 if ($company) {
                     $resolved_relationship['relationships']['company'] = $company;

--- a/src/Functions/actions.php
+++ b/src/Functions/actions.php
@@ -94,33 +94,21 @@ function cmd(string $cmd, string $resource_class, array $parameters = []):void
     logger('cmd', $cmd, $resource_class, $parameters);
     validate_resource_class($resource_class);
 
+    $formatter = validate_formatter($cmd);
+
     if (should_update_cache()) {
-        fetch_all_by_resource($resource_class, validate_formatter($cmd), $parameters);
-    } else {
-        $items = collect(get_all_by_resource_from_cache($resource_class, $parameters));
-
-        if ($company_id = cli_company_id()) {
-            $items = $items->filter(function ($item) use ($company_id) {
-                $relationships = array_get($item, 'variables.relationships');
-                return
-                    array_get($relationships, 'company.id') === $company_id ||
-                    array_get($relationships, 'deal.relationships.company.id') === $company_id;
-            });
-        }
-
-        if (cli_no_ended_deal()) {
-            $items = $items->filter(function ($item) {
-                $attributes = array_get($item, 'variables.relationships.deal.attributes');
-                return !is_null($attributes) && is_null(array_get($attributes, 'closed_at'));
-            });
-        }
-
-        if ($cmd === 'services') {
-            $items = $items->filter(function ($item) {
-                return is_null(array_get($item, 'variables.relationships.deal.attributes.closed_at'));
-            });
-        }
-
-        die(json_encode(['items' => array_values($items->all())]));
+        fetch_all_by_resource($resource_class, $formatter, $parameters);
+        return;
     }
+
+    $open_deals_only = cli_no_ended_deal() || $cmd === 'services';
+    $items = get_all_by_resource_from_cache(
+        $resource_class,
+        $formatter,
+        $parameters,
+        cli_company_id(),
+        $open_deals_only
+    );
+
+    die(json_encode(['items' => array_values($items)]));
 }

--- a/src/Functions/cache.php
+++ b/src/Functions/cache.php
@@ -2,7 +2,6 @@
 
 namespace Alfred\Productive\Functions\cache;
 
-use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 use function Alfred\Productive\Functions\cli\get_cli_args;
 use function Alfred\Productive\Functions\utils\get_root_dir;
 
@@ -16,15 +15,7 @@ function get_cache_dir(): string
     return get_root_dir() . '/cache';
 }
 
-function get_cache(): FilesystemAdapter
+function generate_cache_key(string $resource_class, array $parameters = []): string
 {
-    return new FilesystemAdapter(
-        namespace: 'productive',
-        directory: get_cache_dir(),
-    );
-}
-
-function generate_cache_key(string $resource_class, array $parameters = [])
-{
-    return md5($resource_class . json_encode($parameters));
+    return md5($resource_class . json_encode($parameters, JSON_THROW_ON_ERROR));
 }

--- a/src/Functions/main.php
+++ b/src/Functions/main.php
@@ -81,7 +81,7 @@ function main(array $args):void
         ]],
         'services'  => [Services::class, [
             'filter[time_tracking_enabled]'  => 'true',
-            'filter[trackable_by_person_id]' => 'true',
+            'filter[trackable_by_person_id]' => get_person_id(),
             'filter[person_id]'              => get_person_id(),
             'filter[after]'                  => time_ago('-4 months'),
             'include'                        => to_array_parameter('deal', 'deal.company'),

--- a/tests/Fixtures/cold-cache-refresh.php
+++ b/tests/Fixtures/cold-cache-refresh.php
@@ -1,0 +1,29 @@
+<?php
+
+use Alfred\Productive\Cache\RefreshLock;
+use Alfred\Productive\Cache\SqliteStore;
+use Alfred\Productive\Resources\Deals;
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+[$script, $database, $lockDirectory, $cacheKey] = $argv;
+$store = new SqliteStore($database);
+$lock = new RefreshLock($cacheKey, $lockDirectory);
+
+if (!$lock->acquire()) {
+    fwrite(STDERR, "Could not acquire fixture lock.\n");
+    exit(1);
+}
+
+echo "locked\n";
+fflush(STDOUT);
+usleep(750000);
+
+$generation = $store->beginRefresh($cacheKey, Deals::class, [], 100);
+$store->stageItems($generation, [[
+    'uid' => 'published-by-owner',
+    'title' => 'Published by owner',
+    'variables' => [],
+]], 101);
+$store->publishRefresh($cacheKey, $generation, 110, 60);
+$lock->release();

--- a/tests/Fixtures/concurrent-init.php
+++ b/tests/Fixtures/concurrent-init.php
@@ -1,0 +1,13 @@
+<?php
+
+use Alfred\Productive\Cache\SqliteStore;
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+$database = $argv[1] ?? null;
+if (!is_string($database) || $database === '') {
+    fwrite(STDERR, "Missing database path.\n");
+    exit(1);
+}
+
+new SqliteStore($database);

--- a/tests/Integration/ConcurrentInitializationTest.php
+++ b/tests/Integration/ConcurrentInitializationTest.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Alfred\Productive\Tests\Integration;
+
+use PDO;
+use PHPUnit\Framework\TestCase;
+
+class ConcurrentInitializationTest extends TestCase
+{
+    private string $directory;
+
+    protected function setUp(): void
+    {
+        $this->directory = sys_get_temp_dir() . '/alfred-productive-init-' . bin2hex(random_bytes(8));
+        mkdir($this->directory, 0777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($this->directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $file) {
+            if ($file->isDir()) {
+                rmdir($file->getPathname());
+            } else {
+                unlink($file->getPathname());
+            }
+        }
+
+        rmdir($this->directory);
+    }
+
+    public function testConcurrentInitializationCreatesOneValidSchema(): void
+    {
+        $database = $this->directory . '/productive.sqlite';
+        $fixture = dirname(__DIR__) . '/Fixtures/concurrent-init.php';
+        $processes = [];
+
+        for ($index = 0; $index < 6; $index++) {
+            $pipes = [];
+            $process = proc_open(
+                [PHP_BINARY, $fixture, $database],
+                [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+                $pipes
+            );
+            self::assertIsResource($process);
+            $processes[] = [$process, $pipes];
+        }
+
+        foreach ($processes as [$process, $pipes]) {
+            $stdout = stream_get_contents($pipes[1]);
+            $stderr = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            $exitCode = proc_close($process);
+
+            self::assertSame('', $stdout);
+            self::assertSame('', $stderr);
+            self::assertSame(0, $exitCode);
+        }
+
+        $pdo = new PDO('sqlite:' . $database);
+        self::assertSame(1, (int)$pdo->query('PRAGMA user_version')->fetchColumn());
+        self::assertSame('ok', $pdo->query('PRAGMA integrity_check')->fetchColumn());
+        self::assertSame(
+            3,
+            (int)$pdo->query(
+                "SELECT COUNT(*) FROM sqlite_master
+                WHERE type = 'table' AND name IN ('cache_entries', 'cache_generations', 'items')"
+            )->fetchColumn()
+        );
+    }
+}

--- a/tests/Integration/FetchCacheTest.php
+++ b/tests/Integration/FetchCacheTest.php
@@ -1,0 +1,445 @@
+<?php
+
+namespace Alfred\Productive\Tests\Integration;
+
+use Alfred\Productive\Cache\RefreshLock;
+use Alfred\Productive\Cache\SqliteStore;
+use Alfred\Productive\Resources\Deals;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use function Alfred\Productive\Functions\Resources\fetch\fetch_all_by_resource;
+use function Alfred\Productive\Functions\Resources\fetch\get_all_by_resource_from_cache;
+use function Alfred\Productive\Functions\Resources\fetch\refresh_generation;
+use function Alfred\Productive\Functions\cache\generate_cache_key;
+
+class FetchCacheTest extends TestCase
+{
+    private string $directory;
+
+    private SqliteStore $store;
+
+    private string $logDirectory;
+
+    private bool $createdLogDirectory = false;
+
+    protected function setUp(): void
+    {
+        $this->directory = sys_get_temp_dir() . '/alfred-productive-fetch-' . bin2hex(random_bytes(8));
+        $this->store = new SqliteStore($this->directory . '/productive.sqlite');
+        $this->logDirectory = dirname(__DIR__, 2) . '/logs';
+
+        if (!is_dir($this->logDirectory)) {
+            mkdir($this->logDirectory, 0777, true);
+            $this->createdLogDirectory = true;
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->directory);
+
+        if ($this->createdLogDirectory) {
+            foreach (glob($this->logDirectory . '/*') ?: [] as $file) {
+                unlink($file);
+            }
+            rmdir($this->logDirectory);
+        }
+    }
+
+    public function testMultiPageRefreshPublishesOnlyAfterTheLastPage(): void
+    {
+        $this->publishItems('cache', [$this->item('old')]);
+        $pageFetcher = function (array $parameters): array {
+            $page = (int)$parameters['page[number]'];
+            if ($page === 2) {
+                self::assertSame(['old'], $this->uids($this->store->getItems('cache')));
+            }
+
+            return [
+                'data' => [$this->resource($page === 1 ? 'one' : 'two')],
+                'included' => [],
+                'meta' => ['total_pages' => 2],
+            ];
+        };
+
+        refresh_generation(
+            $this->store,
+            'cache',
+            Deals::class,
+            [],
+            fn (array $resource): array => $this->formatResource($resource),
+            $pageFetcher,
+            60,
+            fn (): int => 200
+        );
+
+        self::assertSame(['one', 'two'], $this->uids($this->store->getItems('cache')));
+    }
+
+    public function testFailureOnALaterPageKeepsStagedItemsInvisible(): void
+    {
+        $this->publishItems('cache', [$this->item('old')]);
+        $pageFetcher = function (array $parameters): array {
+            if ((int)$parameters['page[number]'] === 2) {
+                self::assertSame(['old'], $this->uids($this->store->getItems('cache')));
+                throw new RuntimeException('Second page failed');
+            }
+
+            return [
+                'data' => [$this->resource('replacement')],
+                'included' => [],
+                'meta' => ['total_pages' => 2],
+            ];
+        };
+
+        try {
+            refresh_generation(
+                $this->store,
+                'cache',
+                Deals::class,
+                [],
+                fn (array $resource): array => $this->formatResource($resource),
+                $pageFetcher,
+                60,
+                fn (): int => 200
+            );
+            self::fail('The failed page should abort the refresh.');
+        } catch (RuntimeException $error) {
+            self::assertSame('Second page failed', $error->getMessage());
+        }
+
+        self::assertSame(['old'], $this->uids($this->store->getItems('cache')));
+    }
+
+    public function testValidEmptyResponsePublishesAnEmptyGeneration(): void
+    {
+        $this->publishItems('cache', [$this->item('old')]);
+
+        refresh_generation(
+            $this->store,
+            'cache',
+            Deals::class,
+            [],
+            fn (array $resource): array => $this->formatResource($resource),
+            fn (array $parameters): array => [
+                'data' => [],
+                'included' => [],
+                'meta' => ['total_pages' => 0],
+            ],
+            60,
+            fn (): int => 200
+        );
+
+        self::assertTrue($this->store->hasPublishedGeneration('cache'));
+        self::assertSame([], $this->store->getItems('cache'));
+    }
+
+    public function testMissingPaginationMetadataDoesNotReplacePublishedItems(): void
+    {
+        $this->publishItems('cache', [$this->item('old')]);
+
+        try {
+            refresh_generation(
+                $this->store,
+                'cache',
+                Deals::class,
+                [],
+                fn (array $resource): array => $this->formatResource($resource),
+                fn (array $parameters): array => [
+                    'data' => [$this->resource('partial')],
+                    'included' => [],
+                ],
+                60,
+                fn (): int => 200
+            );
+            self::fail('Missing pagination metadata must fail the refresh.');
+        } catch (RuntimeException $error) {
+            self::assertStringContainsString('missing pagination metadata', $error->getMessage());
+        }
+
+        self::assertSame(['old'], $this->uids($this->store->getItems('cache')));
+    }
+
+    public function testMissingPaginationMetadataOnALaterPageDoesNotPublishPartialData(): void
+    {
+        $this->publishItems('cache', [$this->item('old')]);
+
+        try {
+            refresh_generation(
+                $this->store,
+                'cache',
+                Deals::class,
+                [],
+                fn (array $resource): array => $this->formatResource($resource),
+                function (array $parameters): array {
+                    if ((int)$parameters['page[number]'] === 1) {
+                        return [
+                            'data' => [$this->resource('partial')],
+                            'meta' => ['total_pages' => 2],
+                        ];
+                    }
+
+                    return ['data' => [$this->resource('also-partial')]];
+                },
+                60,
+                fn (): int => 200
+            );
+            self::fail('Missing later-page metadata must fail the refresh.');
+        } catch (RuntimeException $error) {
+            self::assertStringContainsString('missing pagination metadata', $error->getMessage());
+        }
+
+        self::assertSame(['old'], $this->uids($this->store->getItems('cache')));
+    }
+
+    public function testMalformedResponseDoesNotReplacePublishedItems(): void
+    {
+        $this->publishItems('cache', [$this->item('old')]);
+
+        try {
+            refresh_generation(
+                $this->store,
+                'cache',
+                Deals::class,
+                [],
+                fn (array $resource): array => $this->formatResource($resource),
+                fn (array $parameters): array => ['data' => null],
+                60,
+                fn (): int => 200
+            );
+            self::fail('Malformed responses must fail the refresh.');
+        } catch (RuntimeException $error) {
+            self::assertStringContainsString('invalid data collection', $error->getMessage());
+        }
+
+        self::assertSame(['old'], $this->uids($this->store->getItems('cache')));
+    }
+
+    public function testExpirationStartsWhenTheRefreshCompletes(): void
+    {
+        $times = [100, 120, 150];
+        $clock = function () use (&$times): int {
+            return (int)array_shift($times);
+        };
+
+        refresh_generation(
+            $this->store,
+            'cache',
+            Deals::class,
+            [],
+            fn (array $resource): array => $this->formatResource($resource),
+            fn (array $parameters): array => [
+                'data' => [$this->resource('one')],
+                'meta' => ['total_pages' => 1],
+            ],
+            60,
+            $clock
+        );
+
+        self::assertTrue($this->store->isFresh('cache', 209));
+        self::assertFalse($this->store->isFresh('cache', 210));
+    }
+
+    public function testColdReaderWaitsForAnotherProcessToPublish(): void
+    {
+        $parameters = [];
+        $cacheKey = generate_cache_key(Deals::class, $parameters);
+        $fixture = dirname(__DIR__) . '/Fixtures/cold-cache-refresh.php';
+        $lockDirectory = $this->directory . '/locks';
+        $pipes = [];
+        $process = proc_open(
+            [PHP_BINARY, $fixture, $this->directory . '/productive.sqlite', $lockDirectory, $cacheKey],
+            [1 => ['pipe', 'w'], 2 => ['pipe', 'w']],
+            $pipes
+        );
+        self::assertIsResource($process);
+        self::assertSame("locked\n", fgets($pipes[1]));
+
+        try {
+            $items = fetch_all_by_resource(
+                Deals::class,
+                fn (array $resource): array => $this->formatResource($resource),
+                $parameters,
+                $this->store,
+                fn (array $parameters): array => throw new RuntimeException('The waiting reader must not fetch.'),
+                fn (): int => 120,
+                new RefreshLock($cacheKey, $lockDirectory),
+                5.0
+            );
+
+            self::assertSame(['published-by-owner'], $this->uids($items));
+        } finally {
+            $stdout = stream_get_contents($pipes[1]);
+            $stderr = stream_get_contents($pipes[2]);
+            fclose($pipes[1]);
+            fclose($pipes[2]);
+            $exitCode = proc_close($process);
+
+            self::assertSame('', $stdout);
+            self::assertSame('', $stderr);
+            self::assertSame(0, $exitCode);
+        }
+    }
+
+    public function testFreshEmptyPublishedCacheDoesNotTriggerABackgroundRefresh(): void
+    {
+        $cacheKey = generate_cache_key(Deals::class, []);
+        $this->publishItems($cacheKey, []);
+        $fetchCount = 0;
+
+        $items = fetch_all_by_resource(
+            Deals::class,
+            fn (array $resource): array => $this->formatResource($resource),
+            [],
+            $this->store,
+            function (array $parameters) use (&$fetchCount): array {
+                $fetchCount += 1;
+                return ['data' => [], 'meta' => ['total_pages' => 0]];
+            },
+            fn (): int => 120,
+            new RefreshLock($cacheKey, $this->directory . '/locks')
+        );
+
+        self::assertSame([], $items);
+        self::assertSame(0, $fetchCount);
+    }
+
+    public function testExpiredEmptyPublishedCacheRefreshesNormally(): void
+    {
+        $cacheKey = generate_cache_key(Deals::class, []);
+        $this->publishItems($cacheKey, []);
+        $fetchCount = 0;
+
+        $items = fetch_all_by_resource(
+            Deals::class,
+            fn (array $resource): array => $this->formatResource($resource),
+            [],
+            $this->store,
+            function (array $parameters) use (&$fetchCount): array {
+                $fetchCount += 1;
+                return [
+                    'data' => [$this->resource('new')],
+                    'meta' => ['total_pages' => 1],
+                ];
+            },
+            fn (): int => 200,
+            new RefreshLock($cacheKey, $this->directory . '/locks')
+        );
+
+        self::assertSame(['new'], $this->uids($items));
+        self::assertSame(1, $fetchCount);
+    }
+
+    public function testFilteredEmptyPublishedCacheDoesNotTriggerARefresh(): void
+    {
+        $parameters = [];
+        $cacheKey = generate_cache_key(Deals::class, $parameters);
+        $this->publishItems($cacheKey, [$this->item('one', 'company-a')]);
+        $fetchCount = 0;
+
+        $items = get_all_by_resource_from_cache(
+            Deals::class,
+            fn (array $resource): array => $this->formatResource($resource),
+            $parameters,
+            'missing-company',
+            false,
+            $this->store,
+            function (array $parameters) use (&$fetchCount): array {
+                $fetchCount += 1;
+                throw new RuntimeException('A filtered cache hit must not fetch.');
+            },
+            fn (): int => 120,
+            new RefreshLock($cacheKey, $this->directory . '/locks')
+        );
+
+        self::assertSame([], $items);
+        self::assertSame(0, $fetchCount);
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $items
+     */
+    private function publishItems(string $cacheKey, array $items): void
+    {
+        $generation = $this->store->beginRefresh($cacheKey, Deals::class, [], 100);
+        $this->store->stageItems($generation, $items, 101);
+        $this->store->publishRefresh($cacheKey, $generation, 110, 60);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function resource(string $uid): array
+    {
+        return [
+            'id' => $uid,
+            'type' => 'deals',
+            'attributes' => ['name' => ucfirst($uid)],
+            'relationships' => [],
+        ];
+    }
+
+    /**
+     * @param array<string, mixed> $resource
+     * @return array<string, mixed>
+     */
+    private function formatResource(array $resource): array
+    {
+        return $this->item((string)$resource['id']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function item(string $uid, string $companyId = 'company-a'): array
+    {
+        return [
+            'uid' => $uid,
+            'title' => ucfirst($uid),
+            'subtitle' => 'Subtitle',
+            'match' => $uid,
+            'arg' => 'https://example.com/' . $uid,
+            'variables' => [
+                'company_id' => $companyId,
+                'deal_id' => 'deal-' . $uid,
+                'relationships' => [
+                    'deal' => [
+                        'id' => 'deal-' . $uid,
+                        'attributes' => ['closed_at' => null],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $items
+     * @return array<int, string>
+     */
+    private function uids(array $items): array
+    {
+        return array_map(fn (array $item): string => (string)$item['uid'], $items);
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $file) {
+            if ($file->isDir()) {
+                rmdir($file->getPathname());
+            } else {
+                unlink($file->getPathname());
+            }
+        }
+
+        rmdir($directory);
+    }
+}

--- a/tests/Integration/FormatterTest.php
+++ b/tests/Integration/FormatterTest.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Alfred\Productive\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use function Alfred\Productive\Functions\Resources\formatter\deals_formatter;
+use function Alfred\Productive\Functions\Resources\formatter\services_formatter;
+
+class FormatterTest extends TestCase
+{
+    public function testStageLessDealIsNotFormattedAsLost(): void
+    {
+        $item = deals_formatter([
+            'id' => 'deal-1',
+            'attributes' => ['name' => 'Internal budget'],
+            'relationships' => [
+                'company' => [
+                    'id' => 'company-1',
+                    'attributes' => ['company_code' => 'INT', 'name' => 'Internal'],
+                ],
+                'responsible' => [
+                    'id' => 'person-1',
+                    'attributes' => ['first_name' => 'Test', 'last_name' => 'Person'],
+                ],
+                'deal_status' => null,
+            ],
+        ]);
+
+        self::assertSame('Internal budget', $item['title']);
+        self::assertStringNotContainsString('Perdu', $item['subtitle']);
+        self::assertStringContainsString('deal-1', $item['match']);
+    }
+
+    public function testServiceMatchContainsItsRelatedDealId(): void
+    {
+        $item = services_formatter([
+            'id' => 'service-1',
+            'attributes' => [
+                'name' => 'Internal service',
+                'worked_time' => 60,
+                'budgeted_time' => 120,
+                'budget_used' => 10000,
+                'budget_total' => 20000,
+            ],
+            'relationships' => [
+                'deal' => [
+                    'id' => 'deal-1',
+                    'attributes' => [
+                        'name' => 'Internal budget',
+                        'suffix' => null,
+                        'closed_at' => null,
+                    ],
+                    'relationships' => [
+                        'company' => [
+                            'id' => 'company-1',
+                            'attributes' => ['company_code' => 'INT', 'name' => 'Internal'],
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        self::assertSame('deal-1', $item['variables']['deal_id']);
+        self::assertStringContainsString('deal-1', $item['match']);
+    }
+}

--- a/tests/Integration/RefreshLockTest.php
+++ b/tests/Integration/RefreshLockTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Alfred\Productive\Tests\Integration;
+
+use Alfred\Productive\Cache\RefreshLock;
+use PHPUnit\Framework\TestCase;
+
+class RefreshLockTest extends TestCase
+{
+    private string $directory;
+
+    protected function setUp(): void
+    {
+        $this->directory = sys_get_temp_dir() . '/alfred-productive-lock-' . bin2hex(random_bytes(8));
+    }
+
+    protected function tearDown(): void
+    {
+        foreach (glob($this->directory . '/*') ?: [] as $file) {
+            unlink($file);
+        }
+
+        if (is_dir($this->directory)) {
+            rmdir($this->directory);
+        }
+    }
+
+    public function testOnlyOneProcessCanRefreshTheSameCacheKey(): void
+    {
+        $first = new RefreshLock('services', $this->directory);
+        $second = new RefreshLock('services', $this->directory);
+        $different = new RefreshLock('deals', $this->directory);
+
+        self::assertTrue($first->acquire());
+        self::assertFalse($second->acquire());
+        self::assertTrue($different->acquire());
+
+        $first->release();
+        self::assertTrue($second->acquire());
+    }
+
+    public function testReleaseIsIdempotent(): void
+    {
+        $lock = new RefreshLock('services', $this->directory);
+
+        self::assertTrue($lock->acquire());
+        $lock->release();
+        $lock->release();
+        self::assertTrue($lock->acquire());
+    }
+}

--- a/tests/Integration/ResourceUtilsTest.php
+++ b/tests/Integration/ResourceUtilsTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Alfred\Productive\Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use function Alfred\Productive\Functions\Resources\utils\merge_relationships;
+
+class ResourceUtilsTest extends TestCase
+{
+    public function testRowsWithoutRelationshipsArePreserved(): void
+    {
+        $rows = merge_relationships([
+            ['type' => 'companies', 'id' => 'company-1', 'attributes' => ['name' => 'Company']],
+        ], []);
+
+        self::assertSame('company-1', $rows[0]['id']);
+    }
+
+    public function testRelationshipsAndNestedCompaniesAreResolvedFromTheIndex(): void
+    {
+        $rows = merge_relationships([
+            [
+                'type' => 'services',
+                'id' => 'service-1',
+                'relationships' => [
+                    'deal' => ['data' => ['type' => 'deals', 'id' => 'deal-1']],
+                ],
+            ],
+        ], [
+            [
+                'type' => 'deals',
+                'id' => 'deal-1',
+                'relationships' => [
+                    'company' => ['data' => ['type' => 'companies', 'id' => 'company-1']],
+                ],
+            ],
+            [
+                'type' => 'companies',
+                'id' => 'company-1',
+                'attributes' => ['name' => 'Company'],
+            ],
+        ]);
+
+        self::assertSame('deal-1', $rows[0]['relationships']['deal']['id']);
+        self::assertSame(
+            'Company',
+            $rows[0]['relationships']['deal']['relationships']['company']['attributes']['name']
+        );
+    }
+}

--- a/tests/Integration/SqliteStoreTest.php
+++ b/tests/Integration/SqliteStoreTest.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Alfred\Productive\Tests\Integration;
+
+use Alfred\Productive\Cache\SqliteStore;
+use PDO;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class SqliteStoreTest extends TestCase
+{
+    private string $directory;
+
+    private string $database;
+
+    private SqliteStore $store;
+
+    protected function setUp(): void
+    {
+        $this->directory = sys_get_temp_dir() . '/alfred-productive-' . bin2hex(random_bytes(8));
+        $this->database = $this->directory . '/productive.sqlite';
+        $this->store = new SqliteStore($this->database);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->directory);
+    }
+
+    public function testStagedItemsAreInvisibleUntilAtomicallyPublished(): void
+    {
+        $first = $this->store->beginRefresh('services', 'Services', [], 100);
+        $this->store->stageItems($first, [$this->item('old')], 101);
+
+        self::assertFalse($this->store->hasPublishedGeneration('services'));
+        self::assertSame([], $this->store->getItems('services'));
+
+        $this->store->publishRefresh('services', $first, 110, 60);
+        self::assertSame(['old'], $this->uids($this->store->getItems('services')));
+
+        $second = $this->store->beginRefresh('services', 'Services', [], 120);
+        $this->store->stageItems($second, [$this->item('new')], 121);
+
+        self::assertSame(['old'], $this->uids($this->store->getItems('services')));
+
+        $this->store->publishRefresh('services', $second, 130, 60);
+        self::assertSame(['new'], $this->uids($this->store->getItems('services')));
+        self::assertSame(1, $this->store->countPublishedItems('services'));
+    }
+
+    public function testFailedRefreshKeepsTheCompletePublishedGeneration(): void
+    {
+        $published = $this->store->beginRefresh('deals', 'Deals', [], 100);
+        $this->store->stageItems($published, [$this->item('one'), $this->item('two')], 101);
+        $this->store->publishRefresh('deals', $published, 110, 60);
+
+        $failed = $this->store->beginRefresh('deals', 'Deals', [], 200);
+        $this->store->stageItems($failed, [$this->item('replacement')], 201);
+        $this->store->failRefresh('deals', $failed, new RuntimeException('Page two failed'));
+
+        self::assertSame(['one', 'two'], $this->uids($this->store->getItems('deals')));
+    }
+
+    public function testSuccessfulEmptyGenerationIsPublishedAndFresh(): void
+    {
+        $generation = $this->store->beginRefresh('empty', 'Deals', [], 100);
+        $this->store->stageItems($generation, [], 101);
+        $this->store->publishRefresh('empty', $generation, 150, 60);
+
+        self::assertTrue($this->store->hasPublishedGeneration('empty'));
+        self::assertSame(0, $this->store->countPublishedItems('empty'));
+        self::assertSame([], $this->store->getItems('empty'));
+        self::assertTrue($this->store->isFresh('empty', 209));
+        self::assertFalse($this->store->isFresh('empty', 210));
+    }
+
+    public function testCompanyAndOpenDealFiltersCanReturnEmptyWithoutInvalidatingCache(): void
+    {
+        $generation = $this->store->beginRefresh('services', 'Services', [], 100);
+        $this->store->stageItems($generation, [
+            $this->item('open', 'company-a'),
+            $this->item('closed', 'company-a', '2026-01-01T00:00:00Z'),
+            $this->item('unrelated', 'company-b', null, false),
+        ], 101);
+        $this->store->publishRefresh('services', $generation, 110, 60);
+
+        self::assertSame(['open'], $this->uids($this->store->getItems('services', 'company-a', true)));
+        self::assertSame([], $this->store->getItems('services', 'company-b', true));
+        self::assertSame([], $this->store->getItems('services', 'missing-company'));
+        self::assertTrue($this->store->hasPublishedGeneration('services'));
+    }
+
+    public function testEveryStagedItemRequiresAUid(): void
+    {
+        $generation = $this->store->beginRefresh('invalid', 'Deals', [], 100);
+
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('non-empty uid');
+        $this->store->stageItems($generation, [['title' => 'Missing UID']], 101);
+    }
+
+    public function testUnversionedPrototypeDatabaseIsSafelyRebuilt(): void
+    {
+        $legacyDatabase = $this->directory . '/legacy.sqlite';
+        $legacy = new PDO('sqlite:' . $legacyDatabase);
+        $legacy->exec(
+            'CREATE TABLE cache_entries (
+                cache_key TEXT PRIMARY KEY,
+                resource_class TEXT NOT NULL,
+                parameters_json TEXT NOT NULL,
+                status TEXT NOT NULL
+            )'
+        );
+        $legacy->exec(
+            'CREATE TABLE items (
+                cache_key TEXT NOT NULL,
+                uid TEXT NOT NULL,
+                PRIMARY KEY (cache_key, uid)
+            )'
+        );
+        $legacy->exec("INSERT INTO cache_entries VALUES ('legacy', 'Deals', '{}', 'fresh')");
+        $legacy = null;
+
+        $legacyStore = new SqliteStore($legacyDatabase);
+        $pdo = new PDO('sqlite:' . $legacyDatabase);
+
+        self::assertSame(1, (int)$pdo->query('PRAGMA user_version')->fetchColumn());
+        self::assertFalse($legacyStore->hasPublishedGeneration('legacy'));
+        self::assertSame('ok', $pdo->query('PRAGMA integrity_check')->fetchColumn());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function item(
+        string $uid,
+        string $companyId = 'company-a',
+        ?string $closedAt = null,
+        bool $relatedDeal = true
+    ): array {
+        $relationships = [];
+        if ($relatedDeal) {
+            $relationships['deal'] = [
+                'id' => 'deal-' . $uid,
+                'attributes' => ['closed_at' => $closedAt],
+                'relationships' => [
+                    'company' => ['id' => $companyId],
+                ],
+            ];
+        }
+
+        return [
+            'uid' => $uid,
+            'title' => ucfirst($uid),
+            'subtitle' => 'Subtitle',
+            'match' => $uid,
+            'arg' => 'https://example.com/' . $uid,
+            'variables' => [
+                'company_id' => $companyId,
+                'deal_id' => 'deal-' . $uid,
+                'relationships' => $relationships,
+            ],
+        ];
+    }
+
+    /**
+     * @param array<int, array<string, mixed>> $items
+     * @return array<int, string>
+     */
+    private function uids(array $items): array
+    {
+        return array_map(fn (array $item): string => (string)$item['uid'], $items);
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($directory, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($files as $file) {
+            if ($file->isDir()) {
+                rmdir($file->getPathname());
+            } else {
+                unlink($file->getPathname());
+            }
+        }
+
+        rmdir($directory);
+    }
+}


### PR DESCRIPTION
## Summary
- replace the filesystem cache with an indexed SQLite read model
- stage refreshes in isolated generations and publish them atomically only after every API page succeeds
- preserve the last successful generation when a refresh fails and treat valid empty results as cache hits
- coordinate initialization and per-resource refreshes across concurrent Alfred processes
- resolve included relationships through an index and query company/open-deal filters directly in SQLite
- retain the four-month service window and pass the Productive person ID to trackability filtering

## Validation
- refreshed deals and services against Productive using an isolated cache
- verified foreground deal and service searches use the published SQLite generation
- `./bin/php vendor/bin/phpunit` — 24 tests, 89 assertions
- `./bin/php vendor/bin/phpcs src tests`
- `./bin/php vendor/bin/phpstan analyze --no-progress`
- `composer install --dry-run --no-interaction`

The integration suite covers atomic multi-page publication, failed refresh rollback, empty and filtered-empty caches, expiration timing, per-key locking, concurrent initialization, cold-cache handoff, schema migration, relationship indexing, and the deal/service formatter behavior.