### PR TITLE
Include stage-less Productive deals in Alfred

### DIFF
--- a/src/Functions/Resources/formatter.php
+++ b/src/Functions/Resources/formatter.php
@@ -96,7 +96,9 @@ function deals_formatter(array $deal):array
         1 => 'Ouvert',
         2 => 'Gagné',
         3 => 'Perdu',
+        4 => 'Livré',
     ];
+    $status_id = $deal['attributes']['stage_status_id'] ?? null;
 
     $item = [
         'title'     => $deal['attributes']['name'],
@@ -104,7 +106,7 @@ function deals_formatter(array $deal):array
             $company['attributes']['company_code'],
             $company['attributes']['name'],
             isset($responsible['attributes']) ? format_name($responsible) : null,
-            $status[$deal['attributes']['sales_status_id'] ?? 3],
+            $status[$status_id] ?? null,
             isset($deal_status['attributes']) ? $deal_status['attributes']['name'] : null,
         ]),
         'arg'       => sprintf('https://app.productive.io/%s/d/deal/%s', get_org_id(), $deal['id']),
@@ -189,7 +191,7 @@ function services_formatter(array $service):array
         ],
     ];
 
-    $item['match'] = format_match($item);
+    $item['match'] = implode(' ', [format_match($item), $deal['id']]);
 
     return $item;
 }

--- a/src/Functions/main.php
+++ b/src/Functions/main.php
@@ -47,11 +47,10 @@ function main(array $args):void
             'fields[companies]' => to_array_parameter('name', 'company_code'),
         ]],
         'deals'     => [Deals::class, [
-            'filter[sales_status_id]' => '1,2,3',
             'include'                 => to_array_parameter('company', 'responsible', 'deal_status'),
             'fields[deals]'           => to_array_parameter(
                 'name',
-                'sales_status_id',
+                'stage_status_id',
                 'company',
                 'responsible',
                 'deal_status',


### PR DESCRIPTION
## Summary
- remove the sales-stage filter so stage-less Productive budgets are available in deal search
- format deal statuses from `stage_status_id` without treating missing statuses as lost
- include the related deal ID in service matching

## Validation
- verified a stage-less deal appears in deal search
- verified its service appears and can be found using the related deal ID
- `php -l src/Functions/main.php`
- `php -l src/Functions/Resources/formatter.php`
- `phpcs src/Functions/main.php src/Functions/Resources/formatter.php`
- `phpstan analyze src/Functions/main.php src/Functions/Resources/formatter.php`